### PR TITLE
fix/workaround issue w/ Quaternion.Euler issue; rotate single axis at time

### DIFF
--- a/image_cube_A/src/item.ts
+++ b/image_cube_A/src/item.ts
@@ -23,6 +23,11 @@ export default class SignPost implements IScript<Props> {
     QRMaterial.specularIntensity = 0
     QRMaterial.albedoTexture = QRTexture
 
+    //modifying rotations after init. using Transform.rotate to finish rotation
+    //something with Quaternion.Euler(x,y,z) y of certian values causing issues
+    //when deployed from builder works great but when deployed with dcl deploy breaks
+    //if they ever fix we can revert this file
+
     let QRPlane = new Entity()
     QRPlane.setParent(host)
     QRPlane.addComponent(new PlaneShape())
@@ -30,10 +35,12 @@ export default class SignPost implements IScript<Props> {
     QRPlane.addComponent(
       new Transform({
         position: new Vector3(-0.25, 0.97, -0.03),
-        rotation: Quaternion.Euler(180, -15, 0),
+        rotation: Quaternion.Euler(180, 0, 0),//was y=-15
         scale: new Vector3(.55, .55, .55),
       })
     )
+    QRPlane.getComponent(Transform).rotate(Vector3.Down(), 15)
+
     let QRPlane2 = new Entity()
     QRPlane2.setParent(host)
     QRPlane2.addComponent(new PlaneShape())
@@ -41,10 +48,12 @@ export default class SignPost implements IScript<Props> {
     QRPlane2.addComponent(
       new Transform({
         position: new Vector3(-0.4, 0.97, -0.61),
-        rotation: Quaternion.Euler(180, 165, 0),
+        rotation: Quaternion.Euler(180, 0, 0),//was y=165
         scale: new Vector3(.55,.55,.55),
       })
     )
+    QRPlane2.getComponent(Transform).rotate(Vector3.Up(), 165)
+
     let QRPlane3 = new Entity()
     QRPlane3.setParent(host)
     QRPlane3.addComponent(new PlaneShape())
@@ -52,10 +61,12 @@ export default class SignPost implements IScript<Props> {
     QRPlane3.addComponent(
       new Transform({
         position: new Vector3(-0.39, 2.265, -0.04),
-        rotation: Quaternion.Euler(180, 14.5, 0),
+        rotation: Quaternion.Euler(180, 0, 0),//was y=14.5
         scale: new Vector3(.55, .55, .55),
       })
     )
+    QRPlane3.getComponent(Transform).rotate(Vector3.Up(), 14.5)
+
     let QRPlane4 = new Entity()
     QRPlane4.setParent(host)
     QRPlane4.addComponent(new PlaneShape())
@@ -63,9 +74,10 @@ export default class SignPost implements IScript<Props> {
     QRPlane4.addComponent(
       new Transform({
         position: new Vector3(-0.23, 2.265, -0.602),
-        rotation: Quaternion.Euler(180, 193, 0),
+        rotation: Quaternion.Euler(180, 0, 0),//was y=193
         scale: new Vector3(.58, .58, .58),
       })
     )
+    QRPlane4.getComponent(Transform).rotate(Vector3.Up(), 193)
   }
 }

--- a/image_cube_B/src/item.ts
+++ b/image_cube_B/src/item.ts
@@ -23,6 +23,11 @@ export default class SignPost implements IScript<Props> {
     QRMaterial.specularIntensity = 0
     QRMaterial.albedoTexture = QRTexture
 
+    //modifying rotations after init. using Transform.rotate to finish rotation
+    //something with Quaternion.Euler(x,y,z) y of certian values causing issues
+    //when deployed from builder works great but when deployed with dcl deploy breaks
+    //if they ever fix we can revert this file
+
     let QRPlane = new Entity()
     QRPlane.setParent(host)
     QRPlane.addComponent(new PlaneShape())
@@ -30,10 +35,12 @@ export default class SignPost implements IScript<Props> {
     QRPlane.addComponent(
       new Transform({
         position: new Vector3(-0.62, 0.97, -0.25),
-        rotation: Quaternion.Euler(180, 75, 0),
+        rotation: Quaternion.Euler(180, 0, 0),//was y=75
         scale: new Vector3(0.58, 0.58, 0.58),
       })
     )
+    QRPlane.getComponent(Transform).rotate(Vector3.Up(), 75)
+
     let QRPlane2 = new Entity()
     QRPlane2.setParent(host)
     QRPlane2.addComponent(new PlaneShape())
@@ -41,10 +48,12 @@ export default class SignPost implements IScript<Props> {
     QRPlane2.addComponent(
       new Transform({
         position: new Vector3(-0.04, 0.97, -0.4),
-        rotation: Quaternion.Euler(180, 75 + 180, 0),
+        rotation: Quaternion.Euler(180, 0, 0),//was y=75+180
         scale: new Vector3(0.58, 0.58, 0.58),
       })
     )
+    QRPlane2.getComponent(Transform).rotate(Vector3.Up(), 75+180)
+
     let QRPlane3 = new Entity()
     QRPlane3.setParent(host)
     QRPlane3.addComponent(new PlaneShape())
@@ -52,10 +61,12 @@ export default class SignPost implements IScript<Props> {
     QRPlane3.addComponent(
       new Transform({
         position: new Vector3(-0.39, 2.265, -0.03),
-        rotation: Quaternion.Euler(180, 12.4, 0),
+        rotation: Quaternion.Euler(180, 0, 0),//was y=12.4
         scale: new Vector3(0.58, 0.58, 0.58),
       })
     )
+    QRPlane3.getComponent(Transform).rotate(Vector3.Up(), 12.4)
+
     let QRPlane4 = new Entity()
     QRPlane4.setParent(host)
     QRPlane4.addComponent(new PlaneShape())
@@ -63,9 +74,10 @@ export default class SignPost implements IScript<Props> {
     QRPlane4.addComponent(
       new Transform({
         position: new Vector3(-0.23, 2.265, -0.602),
-        rotation: Quaternion.Euler(180, 193, 0),
+        rotation: Quaternion.Euler(180, 0, 0),//was y=193
         scale: new Vector3(0.58, 0.58, 0.58),
       })
     )
+    QRPlane4.getComponent(Transform).rotate(Vector3.Up(), 193)
   }
 }


### PR DESCRIPTION
Some issue with how Quaternion.Euler is calculated.  Maybe between version 6.6.4 of 6.6.3 SDK.  The workaround is only to rotate 1 axis at a time.  I only noticed when using multiple non 0 for 2 or more axis and one of those axis is not a factor of 90 example (180,-15,0).  A brief scan of the code base for usage of Quaternion.Euler I did not see any other uses of this method matching the use case that breaks it.

I tested my workaround deploying out of builder and locally and works in both places.

![fixing-image-rotation](https://user-images.githubusercontent.com/2999141/118347203-60e9bd00-b50f-11eb-8209-fc710d248842.jpeg)
